### PR TITLE
remove | so torrent names show properly

### DIFF
--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -79,7 +79,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 					fieldArray := make([]*discordgo.MessageEmbedField, 0)
 					var counter int = 1
 					for i := range shortened {
-						name := fmt.Sprintf("%d. %s| ", counter, shortened[i].Title)
+						name := fmt.Sprintf("%d. %s ", counter, shortened[i].Title)
 						value := fmt.Sprintf("%s | Seeds: %d | Size: %s", shortened[i].Magnet, shortened[i].Seeds, shortened[i].Size)
 						newField := &discordgo.MessageEmbedField{Name: name, Value: value, Inline: false}
 						fieldArray = append(fieldArray, newField)


### PR DESCRIPTION
currently, every torrent the bot gives out has a | at the end of its name, i tried to fix it but dont know if that's the real solution 
![image](https://user-images.githubusercontent.com/53054786/160200784-61b5bafe-c531-4115-b321-65b15183ab0d.png)
